### PR TITLE
Pass the context through to Jinja2.

### DIFF
--- a/.local/lib/python3/site-packages/snipphthalate/snippet.py
+++ b/.local/lib/python3/site-packages/snipphthalate/snippet.py
@@ -82,8 +82,9 @@ class Jinja2Snippet(Snippet):
       RenderError: The context isn't usable. (Ideally, the is_applicable method
         would prevent this from ever happening.)
     """
-    del context_  # Unused.
-    return {}
+    return {
+        'context': context_,
+    }
 
   def render(self, context_: context.Context) -> str:
     jinja2_context = self.jinja2_context(context_)

--- a/.local/lib/python3/site-packages/snipphthalate/snippet_test.py
+++ b/.local/lib/python3/site-packages/snipphthalate/snippet_test.py
@@ -41,9 +41,9 @@ class Jinja2SnippetTest(unittest.TestCase):
     self.assertTrue(
         snippet.Jinja2Snippet(jinja2.Template('')).is_applicable(self._context))
 
-  def test_context_is_empty_by_default(self):
+  def test_default_context(self):
     self.assertEqual(
-        {},
+        {'context': self._context},
         snippet.Jinja2Snippet(
             jinja2.Template('')).jinja2_context(self._context))
 


### PR DESCRIPTION
This will make it possible for template, and more importantly, filters
to access the context.