### PR TITLE
Remove the default context for Jinja2 snippets.

### DIFF
--- a/.local/lib/python3/site-packages/snipphthalate/registry_test.py
+++ b/.local/lib/python3/site-packages/snipphthalate/registry_test.py
@@ -102,10 +102,9 @@ class DefaultRegistryTest(unittest.TestCase):
                   registry.register(
                       'foo/bar',
                       snippet.Jinja2Snippet(
-                          environment.get_template('foo/__init__.jinja2'),
-                          {'abc': 'zyx'}))
+                          environment.get_template('foo/__init__.jinja2')))
             """),
-        'snippets/foo/__init__.jinja2': '{{abc}}',
+        'snippets/foo/__init__.jinja2': 'zyx'
     })
     self.assertEqual('zyx', registry_.render('foo/bar', self._context))
 

--- a/.local/lib/python3/site-packages/snipphthalate/snippet.py
+++ b/.local/lib/python3/site-packages/snipphthalate/snippet.py
@@ -46,24 +46,18 @@ class Snippet(abc.ABC):
 class Jinja2Snippet(Snippet):
   """Snippet using a Jinja2 template."""
 
-  def __init__(self, template: jinja2.Template,
-               default_context: Optional[Dict[str, Any]] = None):
+  def __init__(self, template: jinja2.Template):
     """Initializer.
 
     Args:
       template: Jinja2 Template to render.
-      default_context: Defaults to use for the template context, or None for no
-        defaults.
     """
     self._template = template
-    self._default_context = default_context or {}
 
   def render(self, context_: context.Context) -> str:
     jinja2_context = {
         'context': context_,
     }
-    for key, value in self._default_context.items():
-      jinja2_context.setdefault(key, value)
     try:
       return self._template.render(jinja2_context)
     except jinja2.TemplateError as e:

--- a/.local/lib/python3/site-packages/snipphthalate/snippet_test.py
+++ b/.local/lib/python3/site-packages/snipphthalate/snippet_test.py
@@ -38,15 +38,14 @@ class Jinja2SnippetTest(unittest.TestCase):
             jinja2.Template('{{context}}')).render(self._context))
 
   def test_render(self):
-    for subtest, path, template, default_context, expected in (
-        ('no_vars', None, 'kumquat', None, 'kumquat'),
-        ('default_var', None, '{{foo}}', {'foo': 'bar'}, 'bar'),
-        ('system_var', 'quux', '{{context.path()}}', None, 'quux'),
+    for subtest, path, template, expected in (
+        ('no_vars', None, 'kumquat', 'kumquat'),
+        ('system_var', 'quux', '{{context.path()}}', 'quux'),
     ):
       with self.subTest(subtest):
         self._context.path.return_value = path
         actual = snippet.Jinja2Snippet(
-            jinja2.Template(template), default_context).render(self._context)
+            jinja2.Template(template)).render(self._context)
         self.assertEqual(expected, actual)
 
   def test_render_error(self):


### PR DESCRIPTION
Equivalent functionality will be provided by plugins.