### PR TITLE
Add a helper function to walk config dirs.

### DIFF
--- a/.local/lib/python3/site-packages/snipphthalate/registry.py
+++ b/.local/lib/python3/site-packages/snipphthalate/registry.py
@@ -17,7 +17,7 @@
 
 import importlib
 import os
-from typing import Iterable, Optional
+from typing import Generator, Iterable, Optional, Tuple
 
 import jinja2
 
@@ -72,6 +72,49 @@ class Registry:
     return snippet_.render(context_)
 
 
+def _walk_config_dirs(
+    config_dirs: Iterable[str],
+    top_level: str,
+    extension: str) -> Generator[Tuple[str, str, str, str], None, None]:
+  """Yields info about files in the config directories.
+
+  __init__.extension files get the tag of the directory they're in, everything
+  else gets the tag of its relative path (minus extension) from its top_level
+  directory.
+
+  Directories and files other than __init__ are ignore if they start with '_'.
+
+  Args:
+    config_dirs: Configuration directories.
+    top_level: Top-level directory in each config dir to walk through.
+    extension: File extension to look for.
+
+  Yields:
+    Tuples: (path to a top-level directory under config_dirs, relative path to a
+    directory within the top-level directory, base filename within the
+    directory, tag for the file)
+  """
+  for config_dir in config_dirs:
+    to_walk = os.path.join(config_dir, top_level)
+    for dirpath, dirnames, filenames in os.walk(to_walk, followlinks=True):
+      dirnames[:] = (x for x in dirnames if not x.startswith('_'))
+      dir_relpath = os.path.relpath(dirpath, to_walk)
+      dir_tag = dir_relpath.replace(os.path.sep, '/')
+      if dir_tag == '.':
+        dir_tag = ''
+      for filename in filenames:
+        if not filename.endswith(extension):
+          continue
+        file_tag, _, _ = filename.rpartition(extension)
+        if file_tag == '__init__':
+          tag = dir_tag
+        elif file_tag.startswith('_'):
+          continue
+        else:
+          tag = '/'.join(((dir_tag,) if dir_tag else ()) + (file_tag,))
+        yield to_walk, dir_relpath, filename, tag
+
+
 class _Jinja2Undefined(jinja2.Undefined):
   """Undefined variable handler for jinja2 snippets.
 
@@ -82,67 +125,57 @@ class _Jinja2Undefined(jinja2.Undefined):
     return '@!{}!@'.format(self._undefined_name)
 
 
-def load_jinja2(registry: Registry, snippet_dirs: Iterable[str]) -> None:
+def load_jinja2(registry: Registry, config_dirs: Iterable[str]) -> None:
   """Loads Jinja2 snippets.
 
   Args:
     registry: Registry to load snippets into.
-    snippet_dirs: Directories to search for snippets in.
+    config_dirs: Directories to search for snippets in.
   """
   environment = jinja2.Environment(
       undefined=_Jinja2Undefined,
       autoescape=False,
       loader=jinja2.FileSystemLoader(
-          [os.path.join(path, 'snippets') for path in snippet_dirs]),
+          [os.path.join(path, 'snippets') for path in config_dirs]),
   )
   environment.filters['comment.block'] = comment.block
 
   # Load snippets with python configuration.
   dirs_with_python = set()
-  for snippet_dir in snippet_dirs:
-    for dirpath, dirnames, filenames in os.walk(
-        os.path.join(snippet_dir, 'snippets'), followlinks=True):
-      for filename in filenames:
-        if filename.endswith('.py'):
-          dirs_with_python.add(dirpath)
-          spec = importlib.util.spec_from_file_location(
-              '<snipphthalate_snippet>', os.path.join(dirpath, filename))
-          module = importlib.util.module_from_spec(spec)
-          spec.loader.exec_module(module)
-          if hasattr(module, 'register_jinja2'):
-            module.register_jinja2(registry, environment)
+  for top_level, dir_relpath, filename, tag in _walk_config_dirs(
+      config_dirs, 'snippets', '.py'):
+    dirs_with_python.add(dir_relpath)
+    spec = importlib.util.spec_from_file_location(
+        '<snipphthalate_snippet>',
+        os.path.join(top_level, dir_relpath, filename))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    if hasattr(module, 'register_jinja2'):
+      module.register_jinja2(registry, environment)
 
   # Load snippets without python configuration.
-  for snippet_dir in snippet_dirs:
-    for dirpath, dirnames, filenames in os.walk(
-        os.path.join(snippet_dir, 'snippets'), followlinks=True):
-      if dirpath in dirs_with_python:
-        del dirnames[:]
-        continue
-      dir_relpath = os.path.relpath(dirpath,
-                                    os.path.join(snippet_dir, 'snippets'))
-      for filename in filenames:
-        if filename.endswith('.jinja2'):
-          file_tag, _, _ = filename.rpartition('.')
-          tag = os.path.normpath(os.path.join(dir_relpath, file_tag))
-          registry.register(
-              tag,
-              snippet.Jinja2Snippet(
-                  environment.get_template(
-                      os.path.join(dir_relpath, filename))))
+  for top_level, dir_relpath, filename, tag in _walk_config_dirs(
+      config_dirs, 'snippets', '.jinja2'):
+    if any((x == os.path.commonpath((x, dir_relpath))
+            for x in dirs_with_python)):
+      continue
+    registry.register(
+        tag,
+        snippet.Jinja2Snippet(
+            environment.get_template(os.path.join(dir_relpath, filename))))
 
 
-def default_registry(snippet_dirs: Optional[Iterable[str]] = None) -> Registry:
+def default_registry(config_dirs: Optional[Iterable[str]] = None) -> Registry:
   """Returns the default snippet registry.
 
   Args:
-    snippet_dirs: Directories to search for snippets in, or None to use the
+    config_dirs: Directories to search for snippets in, or None to use the
       defaults.
   """
-  if snippet_dirs is None:
-    snippet_dirs = [
+  if config_dirs is None:
+    config_dirs = [
         os.path.join(os.getenv('HOME'), '.config', 'snipphthalate'),
     ]
   registry = Registry()
-  load_jinja2(registry, snippet_dirs)
+  load_jinja2(registry, config_dirs)
   return registry


### PR DESCRIPTION
Also, rename snippet_dirs to config_dirs. I picked the 'snippets' path
under those directories on the assumption that I'll later add other
things (e.g., Jinja2 extensions). This commit renames the variables to
be less confusing between 'config-foo' and 'config-foo/snippets'.