### PR TITLE
Add a plugin that's configurable by yaml files.

### DIFF
--- a/.local/lib/python3/site-packages/snipphthalate/plugin.py
+++ b/.local/lib/python3/site-packages/snipphthalate/plugin.py
@@ -18,6 +18,9 @@
 import importlib
 from typing import Any, Dict, Generator, Iterable, List, Optional, Type, TypeVar
 
+import jsonschema
+import yaml
+
 from snipphthalate import context
 
 
@@ -133,3 +136,56 @@ class Jinja2SnippetPlugin(SnippetPlugin):
       variant: Which variant of the snippet to update the context for, or None
         for the default variant.
     """
+
+
+class YamlPlugin(Jinja2SnippetPlugin):
+  """Plugin based on YAML configuration."""
+
+  _SCHEMA = {
+      '$schema': 'http://json-schema.org/draft-04/schema#',
+      'type': 'object',
+      'properties': {
+          'env': {
+              '$ref': '#/definitions/env',
+          },
+          'variants': {
+              'type': 'object',
+              'additionalProperties': {
+                  'type': 'object',
+                  'properties': {
+                      'env': {
+                          '$ref': '#/definitions/env',
+                      },
+                  },
+              },
+          },
+      },
+      'definitions': {
+          'env': {
+              'type': 'object',
+          },
+      },
+  }
+
+  def __init__(self, filename):
+    """Initializer.
+
+    Args:
+      filename: File to load YAML config from.
+    """
+    super().__init__()
+    with open(filename, 'r') as fh:
+      contents = fh.read()
+    self._config = yaml.safe_load(contents)
+    jsonschema.validate(self._config, self._SCHEMA)
+    self.variants.extend(self._config.get('variants', {}).keys())
+
+  def update_context(
+      self,
+      jinja2_context: Dict[str, Any],
+      snipphthalate_context: context.Context,
+      variant: Optional[str]) -> None:
+    jinja2_context.update(self._config.get('env', {}))
+    if variant is not None:
+      jinja2_context.update(
+          self._config.get('variants', {}).get(variant, {}).get('env', {}))

--- a/.local/lib/python3/site-packages/snipphthalate/plugin_test.py
+++ b/.local/lib/python3/site-packages/snipphthalate/plugin_test.py
@@ -84,5 +84,30 @@ class Jinja2SnippetPluginTest(unittest.TestCase):
     self.assertEqual({'foo': 'bar'}, jinja2_context)
 
 
+class YamlPluginTest(unittest.TestCase):
+
+  def test_jinja2(self):
+    with tempfile.NamedTemporaryFile(mode='w') as fh:
+      fh.write(textwrap.dedent("""
+        env:
+          foo: bar
+        variants:
+          quux:
+            env:
+              aardvark: kumquat
+      """))
+      fh.flush()
+      plugin_ = plugin.YamlPlugin(fh.name)
+    jinja2_context = {}
+    plugin_.update_context(
+        jinja2_context, mock.create_autospec(context.Context), None)
+    jinja2_context_quux = {}
+    plugin_.update_context(
+        jinja2_context_quux, mock.create_autospec(context.Context), 'quux')
+    self.assertEqual(['quux'], plugin_.variants)
+    self.assertEqual({'foo': 'bar'}, jinja2_context)
+    self.assertEqual({'foo': 'bar', 'aardvark': 'kumquat'}, jinja2_context_quux)
+
+
 if __name__ == '__main__':
   unittest.main()

--- a/.local/lib/python3/site-packages/snipphthalate/registry.py
+++ b/.local/lib/python3/site-packages/snipphthalate/registry.py
@@ -201,6 +201,19 @@ def load_python_plugins(registry: Registry, config_dirs: Iterable[str]) -> None:
       os.path.join(top_level, dir_relpath, filename)))
 
 
+def load_yaml_plugins(registry: Registry, config_dirs: Iterable[str]) -> None:
+  """Loads YAML plugins.
+
+  Args:
+    registry: Registry to load plugins into.
+    config_dirs: Configuration directories.
+  """
+  for top_level, dir_relpath, filename, tag in _walk_config_dirs(
+      config_dirs, 'snippets', '.yaml'):
+    registry.register_plugin(tag, plugin.YamlPlugin(
+      os.path.join(top_level, dir_relpath, filename)))
+
+
 class _Jinja2Undefined(jinja2.Undefined):
   """Undefined variable handler for jinja2 snippets.
 
@@ -248,5 +261,6 @@ def default_registry(config_dirs: Optional[Iterable[str]] = None) -> Registry:
     ]
   registry = Registry()
   load_python_plugins(registry, config_dirs)
+  load_yaml_plugins(registry, config_dirs)
   load_jinja2_snippets(registry, config_dirs)
   return registry

--- a/.local/lib/python3/site-packages/snipphthalate/registry_test.py
+++ b/.local/lib/python3/site-packages/snipphthalate/registry_test.py
@@ -174,6 +174,22 @@ class DefaultRegistryTest(unittest.TestCase):
     self.assertEqual('kumquat.None', registry_.render('foo/bar', self._context))
     self.assertEqual('kumquat.a', registry_.render('foo/bar(a)', self._context))
 
+  def test_yaml_plugin_with_jinja2_snippet(self):
+    registry_ = self._default_registry({
+        'snippets/foo.yaml':
+            textwrap.dedent("""
+                env:
+                  abc: apples
+                variants:
+                  alt:
+                    env:
+                      abc: oranges
+            """),
+        'snippets/foo.jinja2': '{{abc}}'
+    })
+    self.assertEqual('apples', registry_.render('foo', self._context))
+    self.assertEqual('oranges', registry_.render('foo(alt)', self._context))
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,10 @@ matrix:
     - sudo add-apt-repository -y ppa:jonathonf/vim
     - sudo apt-get update
     - sudo apt-get -y install ./vroom_0.13.0-1_all.deb vim-gtk3 xvfb
+    # Install dependencies of vim scripts.
+    # TODO: Install jsonschema from apt once the version in apt is new enough.
+    - sudo apt-get -y install python3-pip
+    - sudo pip3 install jsonschema
     script:
     - xvfb-run vroom --crawl .
 


### PR DESCRIPTION
Hopefully this gives a clean split between snippets (jinja2), logic
needed for snippets (python), and user configuration of snippets (yaml).
E.g., in the future, the license/*.{py,jinja2} files could go in a
system directory and license/__init__.yaml could configure the variants
and copyright holders.