### PR TITLE
Bail early if gmusicbrowser is not installed.

### DIFF
--- a/.local/lib/dotfiles/update.d/50-gmusicbrowser
+++ b/.local/lib/dotfiles/update.d/50-gmusicbrowser
@@ -22,6 +22,15 @@ import sys
 import textwrap
 import time
 
+
+if __name__ == '__main__':
+  # Bail if gmusicbrowser is not installed, and bail before trying to import
+  # non-standard dependencies.
+  if not shutil.which('gmusicbrowser'):
+    print('Not updating gmusicbrowser, since it\'s not installed.')
+    sys.exit()
+
+
 import gi
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk


### PR DESCRIPTION
This way non-graphical systems don't need GTK dependencies for
dotfiles-update to run successfully.