### PR TITLE
Open manpages with folds open.

### DIFF
--- a/.local/bin/manpager-vim
+++ b/.local/bin/manpager-vim
@@ -18,7 +18,7 @@
 if [ -n "$MAN_PN" ] && [ "${EDITOR##*/}" = vim ]; then
   # TODO: Add --not-a-term once my versions of vim support it.
   # http://vimhelp.appspot.com/starting.txt.html#--not-a-term
-  exec $EDITOR +MANPAGER -
+  exec $EDITOR +MANPAGER +%foldopen -
 else
   exec less
 fi


### PR DESCRIPTION
The MANPAGER command that ships with vim 8.1 seems to cause folds to
start closed despite foldlevelstart's high value. I don't understand
why, but this fixes it.