### PR TITLE
Add SESSION_MANAGER to the list of variables to get from the client.

### DIFF
--- a/.config/tmux/conf.d/50-environment.conf
+++ b/.config/tmux/conf.d/50-environment.conf
@@ -1,0 +1,17 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# X11 Session Manager, https://www.x.org/releases/X11R7.7/doc/libSM/xsmp.html
+set -ga update-environment SESSION_MANAGER


### PR DESCRIPTION
This causes X11 apps started within tmux to connect to the correct
session manager.