### PR TITLE
Use --not-a-term.

### DIFF
--- a/.local/bin/editor-pager
+++ b/.local/bin/editor-pager
@@ -24,9 +24,7 @@ editor_base="${editor_base##*/}"
 
 case "${editor_base}" in
   vim)
-    # TODO: Add --not-a-term once my versions of vim support it.
-    # http://vimhelp.appspot.com/starting.txt.html#--not-a-term
-    exec $editor +'call pager#Pager()' -
+    exec $editor --not-a-term +'call pager#Pager()' -
     ;;
 
   *)


### PR DESCRIPTION
It seems I was wrong about which version of vim introduced this option.