### PR TITLE
Configure the list of pinned apps.

### DIFF
--- a/.config/dconf-load-yaml/conf.d/mate-panel-00.yaml
+++ b/.config/dconf-load-yaml/conf.d/mate-panel-00.yaml
@@ -117,7 +117,16 @@
             - key: popup-delay
               value: "1000"
             - key: pinned-apps
-              reset: false
+              value: >-
+                ['org.gnome.Terminal.desktop',
+                'firefox.desktop',
+                'thunderbird.desktop',
+                'pidgin.desktop',
+                'gmusicbrowser.desktop',
+                'org.musicbrainz.Picard.desktop',
+                'exfalso.desktop',
+                'org.gnome.gThumb.desktop',
+                'caja.desktop']
         # TODO: Get rid of this hack after
         # https://github.com/ubuntu-mate/mate-window-applets/issues/4 is fixed.
         - dir: window-title


### PR DESCRIPTION
It looks like listing a desktop file that isn't installed is a no-op, so
this should work even on computers without all of these apps installed.