### PR TITLE
Fix dock preference loading.

### DIFF
--- a/.config/dconf-load-yaml/conf.d/mate-panel-00.yaml
+++ b/.config/dconf-load-yaml/conf.d/mate-panel-00.yaml
@@ -88,6 +88,8 @@
             value: "'applet'"
           - dir: prefs
             children:
+            - key: first-run
+              value: "false"
             - key: indicator-type
               value: "4"
             - key: multi-ind


### PR DESCRIPTION
When first-run was reset, the dock tried importing settings from an xml
file, which overrode the settings in dconf. This change causes dconf to
be the source of truth.