### PR TITLE
Fix broken jsonschema install command.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
     - sudo apt-get -y install ./vroom_0.13.0-1_all.deb vim-gtk3 xvfb
     # Install dependencies of vim scripts.
     # TODO: Install jsonschema from apt once the version in apt is new enough.
-    - sudo apt-get -y install python3-pip
+    - sudo apt-get -y install python3-pip python3-setuptools
     - sudo pip3 install jsonschema
     script:
     - xvfb-run vroom --crawl .


### PR DESCRIPTION
Installing jsonschema recently started failing with errors about missing
setuptools: https://travis-ci.org/dseomn/dotfiles/jobs/497885649