### PR TITLE
Add a LockSong button to gmusicbrowser's play controls.

### DIFF
--- a/.config/gmusicbrowser/gmbrc.jinja2
+++ b/.config/gmusicbrowser/gmbrc.jinja2
@@ -84,7 +84,7 @@ DefaultOptions_songtree_QueueList:
 DefaultOptions_songtree_SongTree:
   {{ song_tree | indent(2) }}
 Default_picture: {}
-IconTheme: ''
+IconTheme: elementary
 LastFolder_Add: '{{ music_dir }}'
 LastPlayFilter: !Filter "genre:-~:playback/manual-only\x1d"
 Layout: Customized Shimmer Desktop

--- a/.config/gmusicbrowser/layouts/dseomn.layout
+++ b/.config/gmusicbrowser/layouts/dseomn.layout
@@ -14,6 +14,13 @@
 
 
 [Customized Shimmer Desktop] based on Shimmer Desktop
+# Add a LockSong button to the play controls.
+HBButtons = \
+  Prev \
+  Play \
+  Next(click2=NextAlbum) \
+  LockSong(button=1, stock="on:gmb-lock off:gmb-lockopen")
+
 # Change the Cover widget in the lower left.
 VBListCover = \
   _NBList \


### PR DESCRIPTION
Additionally, change the icon theme to elementary, because the default
theme seems to missing the gmb-lockopen icon.