### PR TITLE
Enable the direxpand option.

### DIFF
--- a/.config/shell/interactive.d/50-completion.bash
+++ b/.config/shell/interactive.d/50-completion.bash
@@ -20,3 +20,6 @@ if ! shopt -oq posix; then
     . /etc/bash_completion
   fi
 fi
+
+
+shopt -s direxpand


### PR DESCRIPTION
Previously, variables were getting escaped on expansion, e.g.:

  $ foo=foo
  $ ls $foo/<TAB>
  $ ls \$foo/

That makes it pretty annoying to use variables to store directory paths.
With this change, the expansion is instead:

  $ foo=foo
  $ ls $foo/<TAB>
  $ ls foo/

I'd prefer to keep the variable unexpanded, but I think expanding the
variable is probably going to be less annoying than escaping the dollar
sign.